### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Atmosphere-NX
+permissions:
+  contents: read
 
 on:
   push:
@@ -11,6 +13,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/Atmosphere1.9.2_SwitchFWSupport_20.2.0/security/code-scanning/2](https://github.com/Xieons-Gaming-Corner/Atmosphere1.9.2_SwitchFWSupport_20.2.0/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions to the minimum required. Since most steps only need read access to repository contents, set `permissions: contents: read` at the workflow level (top of the file, after `name:` and before `on:`). For the "Commit artifacts to repository" step, which requires write access to contents, override the permissions at the job level by adding `permissions: contents: write` under the `build:` job. This ensures that the workflow follows the principle of least privilege, only granting write access where necessary.

**Changes needed:**
- Insert `permissions: contents: read` after the `name:` line and before the `on:` block.
- Add `permissions: contents: write` under the `build:` job (after `build:` and before `runs-on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
